### PR TITLE
Handle connection interruptions by exiting with failure

### DIFF
--- a/src/polyswarmclient/ambassador.py
+++ b/src/polyswarmclient/ambassador.py
@@ -1,5 +1,4 @@
 import asyncio
-import functools
 import logging
 import sys
 
@@ -11,8 +10,8 @@ class Ambassador(object):
     def __init__(self, client, testing=0, chains={'home'}):
         self.client = client
         self.chains = chains
-        self.client.on_run.register(functools.partial(Ambassador.handle_run, self))
-        self.client.on_settle_bounty_due.register(functools.partial(Ambassador.handle_settle_bounty, self))
+        self.client.on_run.register(self.handle_run)
+        self.client.on_settle_bounty_due.register(self.handle_settle_bounty)
 
         self.testing = testing
         self.bounties_posted = 0

--- a/src/polyswarmclient/arbiter.py
+++ b/src/polyswarmclient/arbiter.py
@@ -1,5 +1,4 @@
 import asyncio
-import functools
 import logging
 
 from polyswarmclient import Client
@@ -11,10 +10,10 @@ class Arbiter(object):
         self.client = client
         self.chains = chains
         self.scanner = scanner
-        self.client.on_run.register(functools.partial(Arbiter.handle_run, self))
-        self.client.on_new_bounty.register(functools.partial(Arbiter.handle_new_bounty, self))
-        self.client.on_vote_on_bounty_due.register(functools.partial(Arbiter.handle_vote_on_bounty, self))
-        self.client.on_settle_bounty_due.register(functools.partial(Arbiter.handle_settle_bounty, self))
+        self.client.on_run.register(self.handle_run)
+        self.client.on_new_bounty.register(self.handle_new_bounty)
+        self.client.on_vote_on_bounty_due.register(self.handle_vote_on_bounty)
+        self.client.on_settle_bounty_due.register(self.handle_settle_bounty)
 
         self.testing = testing
         self.bounties_seen = 0

--- a/src/polyswarmclient/microengine.py
+++ b/src/polyswarmclient/microengine.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import functools
 
 from polyswarmclient import Client
 from polyswarmclient.events import RevealAssertion, SettleBounty
@@ -11,9 +10,9 @@ class Microengine(object):
         self.client = client
         self.chains = chains
         self.scanner = scanner
-        self.client.on_new_bounty.register(functools.partial(Microengine.handle_new_bounty, self))
-        self.client.on_reveal_assertion_due.register(functools.partial(Microengine.handle_reveal_assertion, self))
-        self.client.on_settle_bounty_due.register(functools.partial(Microengine.handle_settle_bounty, self))
+        self.client.on_new_bounty.register(self.handle_new_bounty)
+        self.client.on_reveal_assertion_due.register(self.handle_reveal_assertion)
+        self.client.on_settle_bounty_due.register(self.handle_settle_bounty)
 
         self.testing = testing
         self.bounties_seen = 0

--- a/src/polyswarmclient/reporter.py
+++ b/src/polyswarmclient/reporter.py
@@ -1,6 +1,5 @@
 import asyncio
 import base64
-import functools
 import logging
 import json
 import os
@@ -66,11 +65,11 @@ class Reporter(object):
         self.chains = chains
         self.testing = testing
         self.client = Client(polyswarmd_uri, keyfile, password, api_key, testing > 0, insecure_transport)
-        self.client.on_new_block.register(functools.partial(Reporter.run_task, self))
-        self.client.on_new_block.register(functools.partial(Reporter.block_checker, self))
-        self.client.on_settle_bounty_due.register(functools.partial(Reporter.handle_settle_bounty, self))
-        # self.client.on_new_verdict.register(functools.partial(Reporter.handle_verdict, self))
-        self.client.on_new_assertion.register(functools.partial(Reporter.handle_assertion, self))
+        self.client.on_new_block.register(self.run_task)
+        self.client.on_new_block.register(self.block_checker)
+        self.client.on_settle_bounty_due.register(self.handle_settle_bounty)
+        # self.client.on_new_verdict.register(self.handle_verdict)
+        self.client.on_new_assertion.register(self.handle_assertion)
 
         self.bounties = {}
         self.submitted = False


### PR DESCRIPTION
Related to polyswarm/ambassador#1 (thanks @strazzere!) , currently we've decided its better to exit on error while we come up with a better recovery strategy given potentially stale state in the client.