### PR TITLE
Vartifacts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.5-jessie
 LABEL maintainer="PolySwarm Developers <info@polyswarm.io>"
 
 ENV DOCKERIZE_VERSION v0.6.1
+
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
     && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,13 @@ setup(
     license='MIT',
     install_requires=parse_requirements(),
     include_package_data=True,
-    packages=['polyswarmclient', 'ambassador', 'arbiter', 'microengine', 'arbiter.verbatimdb'],
+    packages=['polyswarmclient', 'ambassador', 'arbiter', 'microengine', 'arbiter.verbatimdb', 'corpus'],
     package_dir={
         'polyswarmclient': 'src/polyswarmclient',
         'ambassador': 'src/ambassador',
         'arbiter': 'src/arbiter',
         'microengine': 'src/microengine',
+        'corpus': 'src/corpus',
         'arbiter.verbatimdb': 'src/arbiter/verbatimdb',
     },
     entry_points={

--- a/src/arbiter/verbatim.py
+++ b/src/arbiter/verbatim.py
@@ -21,7 +21,7 @@ class VerbatimArbiter(Arbiter):
         super().__init__(client, testing, None, chains)
         db_pth = os.path.join(ARTIFACT_DIRECTORY, 'truth.db')
 
-        if not os.path.exists(db_pth) and os.getenv("MALICIOUS_BOOTSTRAP_URL"):
+        if os.getenv("MALICIOUS_BOOTSTRAP_URL"):
 
             d = DownloadToFileSystemCorpus(base_dir=ARTIFACT_DIRECTORY)
             d.download_truth()

--- a/src/arbiter/verbatimdb/__main__.py
+++ b/src/arbiter/verbatimdb/__main__.py
@@ -1,30 +1,7 @@
 import click
-import sqlite3
-import hashlib
-import os
 
-def generate_db(db_file, malicious_dir, benign_dir):
-    conn = sqlite3.connect(db_file)
-    cursor = conn.cursor()
-    cursor.execute('''CREATE TABLE IF NOT EXISTS files (name text, truth int)''')
-    benign = os.listdir(benign_dir)
-    for b in benign:
-        insert(cursor, os.path.join(benign_dir, b), 0)
-        conn.commit()
+from arbiter.verbatimdb.db import generate_db
 
-    malicious = os.listdir(malicious_dir)
-    for m in malicious:
-        insert(cursor, os.path.join(malicious_dir, m), 1)
-        conn.commit()
-
-    conn.close()
-
-def insert(cursor, path, result):
-    with open (path, "rb") as f:
-        data = f.read()
-        h = hashlib.sha256(data).hexdigest()
-        value = (h, result)
-        cursor.execute('''INSERT INTO files values (?, ?)''', value)
 
 @click.command()
 @click.option('--malicious', type=click.Path(exists=True), default='./artifacts/malicious',

--- a/src/arbiter/verbatimdb/db.py
+++ b/src/arbiter/verbatimdb/db.py
@@ -1,0 +1,28 @@
+import hashlib
+import os
+import sqlite3
+
+
+def generate_db(db_file, malicious_dir, benign_dir):
+    conn = sqlite3.connect(db_file)
+    cursor = conn.cursor()
+    cursor.execute('''CREATE TABLE IF NOT EXISTS files (name text, truth int)''')
+    benign = os.listdir(benign_dir)
+    for b in benign:
+        insert(cursor, os.path.join(benign_dir, b), 0)
+        conn.commit()
+
+    malicious = os.listdir(malicious_dir)
+    for m in malicious:
+        insert(cursor, os.path.join(malicious_dir, m), 1)
+        conn.commit()
+
+    conn.close()
+
+
+def insert(cursor, path, result):
+    with open (path, "rb") as f:
+        data = f.read()
+        h = hashlib.sha256(data).hexdigest()
+        value = (h, result)
+        cursor.execute('''INSERT INTO files values (?, ?)''', value)

--- a/src/corpus/__init__.py
+++ b/src/corpus/__init__.py
@@ -1,0 +1,64 @@
+import os
+import tempfile
+import urllib.request
+import logging
+from subprocess import check_call
+from arbiter.verbatimdb.__main__ import generate_db
+
+MALICIOUS_BOOTSTRAP_URL = os.getenv('MALICIOUS_BOOTSTRAP_URL')
+ARCHIVE_PW = os.getenv('ARCHIVE_PASSWORD')
+
+
+class DownloadToFileSystemCorpus(object):
+    def __init__(self, base_dir=None):
+        self.url = MALICIOUS_BOOTSTRAP_URL
+        self.base_dir = base_dir if base_dir else tempfile.mkdtemp(suffix="malware-corpus")
+        self.truth_fname = "truth.db"
+        self.truth_db_pth = os.path.join(self.base_dir, self.truth_fname)
+
+    @property
+    def mal_path(self):
+        return os.path.join(self.base_dir, "malicious")
+
+    @property
+    def benign_pth(self):
+        return os.path.join(self.base_dir, "malicious")
+
+    def download_and_unpack(self):
+        logging.info("Downloading to {0}".format(self.base_dir))
+        for is_mal, package_name in [(True, "malicious.tgz.gpg"), (False, "benign.tgz.gpg")]:
+
+            mal_dir = self.mal_path if is_mal else self.benign_pth
+            archive_pth = os.path.join(mal_dir, package_name)
+            archive_dst = mal_dir
+            if not os.path.isdir(archive_dst):
+                os.mkdir(archive_dst)
+            archive_tgz = archive_pth.rstrip(".gpg")
+            r = urllib.request.urlretrieve("{0}/{1}".format(self.url, package_name), archive_pth)
+            check_call(["gpg", "--batch", "--passphrase", ARCHIVE_PW, "--decrypt",
+                        "--no-use-agent", "--cipher-algo", "AES256",
+                         "--yes", "-o", archive_tgz, archive_pth])
+            # can do with python tar file, but being lazy
+            check_call(["tar", "xf", archive_tgz, "-C", archive_dst])
+            os.unlink(archive_tgz)
+            os.unlink(archive_pth)
+
+    def _get_pth_listing(self, p):
+        artifacts = []
+        for root, dirs, files in os.walk(p):
+            for f in files:
+                artifacts.append(os.path.join(root, f))
+        return artifacts
+
+    def get_malicious_file_list(self):
+        return self._get_pth_listing(self.mal_path)
+
+    def get_benign_file_list(self):
+        return self._get_pth_listing(self.benign_pth)
+
+    def download_truth(self):
+        r = urllib.request.urlretrieve("{0}/{1}".format(self.url, self.truth_fname), self.truth_db_pth)
+        pass
+
+    def generate_truth(self):
+        d = generate_db(self.truth_db_pth, self.mal_path, self.benign_pth)

--- a/src/corpus/__init__.py
+++ b/src/corpus/__init__.py
@@ -57,8 +57,9 @@ class DownloadToFileSystemCorpus(object):
         return self._get_pth_listing(self.benign_pth)
 
     def download_truth(self):
-        r = urllib.request.urlretrieve("{0}/{1}".format(self.url, self.truth_fname), self.truth_db_pth)
-        pass
+        u = "{0}/{1}".format(self.url, self.truth_fname)
+        logging.info("Fetching truth database {0}".format(u))
+        r = urllib.request.urlretrieve(u, self.truth_db_pth)
 
     def generate_truth(self):
         d = generate_db(self.truth_db_pth, self.mal_path, self.benign_pth)

--- a/src/corpus/test_dl.py
+++ b/src/corpus/test_dl.py
@@ -2,7 +2,6 @@ import os
 import unittest
 from corpus import DownloadToFileSystemCorpus
 
-
 class DownloaderUnitTest(unittest.TestCase):
 
     def test_download_truth_artifact(self):

--- a/src/corpus/test_dl.py
+++ b/src/corpus/test_dl.py
@@ -1,0 +1,21 @@
+import os
+import unittest
+from corpus import DownloadToFileSystemCorpus
+
+
+class DownloaderUnitTest(unittest.TestCase):
+
+    def test_download_truth_artifact(self):
+        d = DownloadToFileSystemCorpus()
+        t = d.download_truth()
+        self.assertTrue(os.path.exists(d.truth_db_pth), msg="Couldn't download truth db")
+
+    def test_download_raw_artifacts(self):
+        d = DownloadToFileSystemCorpus()
+        d.download_and_unpack()
+
+        self.assertTrue(d.get_malicious_file_list())
+        self.assertTrue(d.get_benign_file_list())
+
+        d.generate_truth()
+        self.assertTrue(os.path.exists(d.truth_db_pth))


### PR DESCRIPTION
Replace `withartifacts` docker tag with a Pythonic puller that downloads a basic corpus to arbiter and ambassador. Tested in staging.