### PR TITLE
force PS to TLS 1.2

### DIFF
--- a/docker/windows/pscwin/choco.ps1
+++ b/docker/windows/pscwin/choco.ps1
@@ -1,6 +1,7 @@
 
 Set-ExecutionPolicy Bypass -Scope Process -Force
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 choco install python --version 3.5.4 -y
 choco install git -y


### PR DESCRIPTION
This forces powershell to use TLS 1.2.  Hope this fixes e2e issue downloading the choco install