### PR TITLE
Renamed Microengine AbstractMicroengine and associated updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,32 @@
 
 Client library to simplify interacting with a polyswarmd instance from Python
 
+## Important Changes
 
-## Running Tests
+### The update from 0.1.2 to 0.2.0 is a breaking change for Microengines. 
 
-Use tox, or install dependencies in a virtual environment and run `pytest`
+Microgengine implementations using polyswarmclient <= 0.1.2 used this pattern:
+
+```
+from polyswarmclient.microengine import Microengine
+
+class CustomMicroengine(Microengine):
+    # Microengine implementation here
+```
+
+For polyswarmclient >= 0.2.0, Microengine implementations should use the following pattern:
+```
+from polyswarmclient.abstractmicroengine import AbstractMicroengine
+
+class Microengine(AbstractMicroengine):
+    # Microengine implementation here
+```
+
+This implies that custom microengines now only need to provide their python module name to the `--backend` argument
+instead of `module_name:CustomMicroengine`.
+
+Additionally, as of polyswarmclient 0.2.0, AbstractMicroengine.scan() will now raise an exception if it 
+has not been overridden by a sub-class and the subclass did not provide a scanner to the constructor.
 
 
 ## Configuring Development Environment
@@ -131,3 +153,6 @@ You will need to use your web browser for this step.
 Browse to: https://www.jetbrains.com/pycharm/download/#section=windows and click the `Download` button under Community.
 Once you've downloaded the installer, run it to install PyCharm.
 
+## Running Tests
+
+Use tox, or install dependencies in a virtual environment and run `pytest`

--- a/README.md
+++ b/README.md
@@ -8,18 +8,48 @@ Client library to simplify interacting with a polyswarmd instance from Python
 
 ## Important Changes
 
-### The update from 0.1.2 to 0.2.0 is a breaking change for Microengines. 
+### The update from 0.1.2 to 0.2.0 is a breaking change for Ambassadors, Arbiters, and Microengines.
 
-Microgengine implementations using polyswarmclient <= 0.1.2 used this pattern:
+#### polyswarmclient <= 0.1.2 used this pattern:
 
+**Ambassadors**
+```
+from polyswarmclient.ambassador import Ambassador
+class CustomAmbassador(Ambassador):
+    # Ambassador implementation here
+```
+
+**Arbiters**
+```
+from polyswarmclient.arbiter import Arbiter
+class CustomArbiter(Arbiter):
+    # Arbiter implementation here
+```
+
+**Microengines**
 ```
 from polyswarmclient.microengine import Microengine
-
 class CustomMicroengine(Microengine):
     # Microengine implementation here
 ```
 
-For polyswarmclient >= 0.2.0, Microengine implementations should use the following pattern:
+#### polyswarmclient >= 0.2.0, instead use the following pattern:
+
+**Ambassadors**
+```
+from polyswarmclient.abstractambassador import AbstractAmbassador
+class Ambassador(AbstractAmbassador):
+    # Ambassador implementation here
+```
+
+**Arbiters**
+```
+from polyswarmclient.abstractarbiter import AbstractArbiter
+class Arbiter(AbstractArbiter):
+    # Arbiter implementation here
+```
+
+**Microengines**
 ```
 from polyswarmclient.abstractmicroengine import AbstractMicroengine
 
@@ -30,9 +60,11 @@ class Microengine(AbstractMicroengine):
 This implies that custom microengines now only need to provide their python module name to the `--backend` argument
 instead of `module_name:CustomMicroengine`.
 
-Additionally, as of polyswarmclient 0.2.0, AbstractMicroengine.scan() will now raise an exception if it 
-has not been overridden by a sub-class and the subclass did not provide a scanner to the constructor.
+Additionally, as of `polyswarmclient >= 0.2.0`:
 
+* `AbstractArbiter.scan()` and `AbstractMicroengine.scan()` will now raise an exception if it 
+has not been overridden by a sub-class and the subclass did not provide a scanner to the constructor.
+* `AbstractAmbassador.next_bounty()` will now raise an exception if not overridden by sub-class.
 
 ## Configuring Development Environment
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def parse_requirements():
 
 setup(
     name='polyswarm-client',
-    version='0.1.2',
+    version='0.2.0',
     description='Client library to simplify interacting with a polyswarmd instance',
     author='PolySwarm Developers',
     author_email='info@polyswarm.io',

--- a/src/ambassador/__main__.py
+++ b/src/ambassador/__main__.py
@@ -3,8 +3,8 @@ import importlib
 import logging
 import sys
 
-from ambassador.eicar import EicarAmbassador
-from ambassador.filesystem import FilesystemAmbassador
+from ambassador.eicar import Ambassador as EicarAmbassador
+from ambassador.filesystem import Ambassador as FilesystemAmbassador
 from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Initialize logger

--- a/src/ambassador/__main__.py
+++ b/src/ambassador/__main__.py
@@ -1,10 +1,8 @@
 import click
-import importlib
+import importlib.util
 import logging
 import sys
 
-from ambassador.eicar import Ambassador as EicarAmbassador
-from ambassador.filesystem import Ambassador as FilesystemAmbassador
 from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -22,19 +20,23 @@ def choose_backend(backend):
     Raises:
         (Exception): If backend is not found
     """
-    ambassador_class = None
-    if backend == 'eicar':
-        ambassador_class = EicarAmbassador
-    elif backend == 'filesystem':
-        ambassador_class = FilesystemAmbassador
+    backend_list = backend.split(":")
+    module_name_string = backend_list[0]
+
+    # determine if this string is a module that can be imported as-is or as sub-module of the ambassador package
+    mod_spec = importlib.util.find_spec(module_name_string) or importlib.util.find_spec("ambassador.{0}".format(module_name_string))
+    if mod_spec is None:
+        raise Exception("Ambassador backend `{0}` cannot be imported as a python module.".format(backend))
+
+    # have valid module that can be imported, so import it.
+    ambassador_module = importlib.import_module(mod_spec.name)
+
+    # find Ambassador class in this module
+    if hasattr(ambassador_module, "Ambassador"):
+        ambassador_class = ambassador_module.Ambassador
+    elif len(backend_list) == 2 and hasattr(ambassador_module, backend_list[1]):
+        ambassador_class = getattr(ambassador_module, backend_list[1])
     else:
-        import_l = backend.split(":")
-        ambassador_module_s = import_l[0]
-
-        ambassador_module = importlib.import_module(ambassador_module_s)
-        ambassador_class = ambassador_module.Ambassador if ":" not in backend else getattr(ambassador_module, import_l[1])
-
-    if ambassador_class is None:
         raise Exception("No ambassador backend found {0}".format(backend))
 
     return ambassador_class

--- a/src/ambassador/eicar.py
+++ b/src/ambassador/eicar.py
@@ -2,7 +2,7 @@ import base64
 import logging
 import random
 
-from polyswarmclient.ambassador import Ambassador
+from polyswarmclient.abstractambassador import AbstractAmbassador
 
 logger = logging.getLogger(__name__)  # Initialize logger
 
@@ -11,7 +11,7 @@ NOT_EICAR = 'this is not malicious'
 ARTIFACTS = [('eicar', EICAR), ('not_eicar', NOT_EICAR)]
 
 
-class EicarAmbassador(Ambassador):
+class Ambassador(AbstractAmbassador):
     """Ambassador which submits the EICAR test file"""
 
     async def next_bounty(self, chain):

--- a/src/ambassador/filesystem.py
+++ b/src/ambassador/filesystem.py
@@ -2,7 +2,7 @@ import logging
 import random
 import os
 
-from polyswarmclient.ambassador import Ambassador
+from polyswarmclient.abstractambassador import AbstractAmbassador
 from polyswarmclient.corpus import DownloadToFileSystemCorpus
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -11,7 +11,8 @@ ARTIFACT_DIRECTORY = os.getenv('ARTIFACT_DIRECTORY', 'docker/artifacts')
 ARTIFACT_BLACKLIST = os.getenv('ARTIFACT_BLACKLIST', 'truth.db').split(',')
 BOUNTY_TEST_DURATION_BLOCKS = int(os.getenv('BOUNTY_TEST_DURATION_BLOCKS', 5))
 
-class FilesystemAmbassador(Ambassador):
+
+class Ambassador(AbstractAmbassador):
     """Ambassador which submits artifacts from a directory"""
 
     def __init__(self, client, testing=0, chains=None, watchdog=0):

--- a/src/arbiter/__main__.py
+++ b/src/arbiter/__main__.py
@@ -1,9 +1,8 @@
 import click
-import importlib
+import importlib.util
 import logging
 import sys
 
-from arbiter.verbatim import Arbiter as VerbatimArbiter
 from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -21,17 +20,23 @@ def choose_backend(backend):
     Raises:
         (Exception): If backend is not found
     """
-    arbiter_class = None
-    if backend == 'verbatim':
-        arbiter_class = VerbatimArbiter
+    backend_list = backend.split(":")
+    module_name_string = backend_list[0]
+
+    # determine if this string is a module that can be imported as-is or as sub-module of the arbiter package
+    mod_spec = importlib.util.find_spec(module_name_string) or importlib.util.find_spec("arbiter.{0}".format(module_name_string))
+    if mod_spec is None:
+        raise Exception("Arbiter backend `{0}` cannot be imported as a python module.".format(backend))
+
+    # have valid module that can be imported, so import it.
+    arbiter_module = importlib.import_module(mod_spec.name)
+
+    # find Arbiter class in this module
+    if hasattr(arbiter_module, "Arbiter"):
+        arbiter_class = arbiter_module.Arbiter
+    elif len(backend_list) == 2 and hasattr(arbiter_module, backend_list[1]):
+        arbiter_class = getattr(arbiter_module, backend_list[1])
     else:
-        import_l = backend.split(":")
-        arbiter_module_s = import_l[0]
-
-        arbiter_module = importlib.import_module(arbiter_module_s)
-        arbiter_class = arbiter_module.Arbiter if ":" not in backend else getattr(arbiter_module, import_l[1])
-
-    if arbiter_class is None:
         raise Exception("No arbiter backend found {0}".format(backend))
 
     return arbiter_class

--- a/src/arbiter/__main__.py
+++ b/src/arbiter/__main__.py
@@ -3,7 +3,7 @@ import importlib
 import logging
 import sys
 
-from arbiter.verbatim import VerbatimArbiter
+from arbiter.verbatim import Arbiter as VerbatimArbiter
 from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Initialize logger

--- a/src/arbiter/verbatim.py
+++ b/src/arbiter/verbatim.py
@@ -4,7 +4,7 @@ import hashlib
 import logging
 import os
 
-from polyswarmclient.arbiter import Arbiter
+from polyswarmclient.abstractarbiter import AbstractArbiter
 from polyswarmclient.corpus import DownloadToFileSystemCorpus
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -12,7 +12,7 @@ ARTIFACT_DIRECTORY = os.getenv('ARTIFACT_DIRECTORY', 'docker/artifacts')
 EICAR = base64.b64decode(b'WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo=')
 
 
-class VerbatimArbiter(Arbiter):
+class Arbiter(AbstractArbiter):
     """Arbiter which matches hashes to a database of known samples"""
 
     def __init__(self, client, testing=0, scanner=None, chains=None):

--- a/src/microengine/__main__.py
+++ b/src/microengine/__main__.py
@@ -3,11 +3,6 @@ import importlib
 import logging
 import sys
 
-from microengine.clamav import Microengine as ClamavMicroengine
-from microengine.eicar import Microengine as EicarMicroengine
-from microengine.multi import Microengine as MultiMicroengine
-from microengine.scratch import Microengine as ScratchMicroengine
-from microengine.yara import Microengine as YaraMicroengine
 from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -25,23 +20,11 @@ def choose_backend(backend):
     Raises:
         (Exception): If backend is not found
     """
-    micro_engine_class = None
-    if backend == 'scratch':
-        micro_engine_class = ScratchMicroengine
-    elif backend == 'eicar':
-        micro_engine_class = EicarMicroengine
-    elif backend == 'clamav':
-        micro_engine_class = ClamavMicroengine
-    elif backend == 'yara':
-        micro_engine_class = YaraMicroengine
-    elif backend == 'multi':
-        micro_engine_class = MultiMicroengine
-    else:
-        import_l = backend.split(":")
-        micro_engine_module_s = import_l[0]
+    import_l = backend.split(":")
+    micro_engine_module_s = import_l[0]
 
-        micro_engine_module = importlib.import_module(micro_engine_module_s)
-        micro_engine_class = micro_engine_module.Microengine if ":" not in backend else getattr(micro_engine_module, import_l[1])
+    micro_engine_module = importlib.import_module(micro_engine_module_s)
+    micro_engine_class = micro_engine_module.Microengine if ":" not in backend else getattr(micro_engine_module, import_l[1])
 
     if micro_engine_class is None:
         raise Exception("No microengine backend found {0}".format(backend))

--- a/src/microengine/__main__.py
+++ b/src/microengine/__main__.py
@@ -3,11 +3,6 @@ import importlib
 import logging
 import sys
 
-from microengine.clamav import Microengine as ClamavMicroengine
-from microengine.eicar import Microengine as EicarMicroengine
-from microengine.multi import Microengine as MultiMicroengine
-from microengine.scratch import Microengine as ScratchMicroengine
-from microengine.yara import Microengine as YaraMicroengine
 from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -27,15 +22,20 @@ def choose_backend(backend):
     """
     micro_engine_class = None
     if backend == 'scratch':
-        micro_engine_class = ScratchMicroengine
+        import microengine.scratch
+        micro_engine_class = microengine.scratch.Microengine
     elif backend == 'eicar':
-        micro_engine_class = EicarMicroengine
+        import microengine.eicar
+        micro_engine_class = microengine.eicar.Microengine
     elif backend == 'clamav':
-        micro_engine_class = ClamavMicroengine
+        import microengine.clamav
+        micro_engine_class = microengine.clamav.Microengine
     elif backend == 'yara':
-        micro_engine_class = YaraMicroengine
+        import microengine.yara
+        micro_engine_class = microengine.yara.Microengine
     elif backend == 'multi':
-        micro_engine_class = MultiMicroengine
+        import microengine.multi
+        micro_engine_class = microengine.multi.Microengine
     else:
         import_l = backend.split(":")
         micro_engine_module_s = import_l[0]

--- a/src/microengine/__main__.py
+++ b/src/microengine/__main__.py
@@ -3,6 +3,11 @@ import importlib
 import logging
 import sys
 
+from microengine.clamav import Microengine as ClamavMicroengine
+from microengine.eicar import Microengine as EicarMicroengine
+from microengine.multi import Microengine as MultiMicroengine
+from microengine.scratch import Microengine as ScratchMicroengine
+from microengine.yara import Microengine as YaraMicroengine
 from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -20,11 +25,23 @@ def choose_backend(backend):
     Raises:
         (Exception): If backend is not found
     """
-    import_l = backend.split(":")
-    micro_engine_module_s = import_l[0]
+    micro_engine_class = None
+    if backend == 'scratch':
+        micro_engine_class = ScratchMicroengine
+    elif backend == 'eicar':
+        micro_engine_class = EicarMicroengine
+    elif backend == 'clamav':
+        micro_engine_class = ClamavMicroengine
+    elif backend == 'yara':
+        micro_engine_class = YaraMicroengine
+    elif backend == 'multi':
+        micro_engine_class = MultiMicroengine
+    else:
+        import_l = backend.split(":")
+        micro_engine_module_s = import_l[0]
 
-    micro_engine_module = importlib.import_module(micro_engine_module_s)
-    micro_engine_class = micro_engine_module.Microengine if ":" not in backend else getattr(micro_engine_module, import_l[1])
+        micro_engine_module = importlib.import_module(micro_engine_module_s)
+        micro_engine_class = micro_engine_module.Microengine if ":" not in backend else getattr(micro_engine_module, import_l[1])
 
     if micro_engine_class is None:
         raise Exception("No microengine backend found {0}".format(backend))

--- a/src/microengine/__main__.py
+++ b/src/microengine/__main__.py
@@ -3,11 +3,11 @@ import importlib
 import logging
 import sys
 
-from microengine.clamav import ClamavMicroengine
-from microengine.eicar import EicarMicroengine
-from microengine.multi import MultiMicroengine
-from microengine.scratch import ScratchMicroengine
-from microengine.yara import YaraMicroengine
+from microengine.clamav import Microengine as ClamavMicroengine
+from microengine.eicar import Microengine as EicarMicroengine
+from microengine.multi import Microengine as MultiMicroengine
+from microengine.scratch import Microengine as ScratchMicroengine
+from microengine.yara import Microengine as YaraMicroengine
 from polyswarmclient.config import init_logging
 
 logger = logging.getLogger(__name__)  # Initialize logger

--- a/src/microengine/clamav.py
+++ b/src/microengine/clamav.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from io import BytesIO
-from polyswarmclient.microengine import Microengine
+from polyswarmclient.abstractmicroengine import AbstractMicroengine
 from polyswarmclient.scanner import Scanner
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -40,7 +40,7 @@ class ClamavScanner(Scanner):
         return True, False, ''
 
 
-class ClamavMicroengine(Microengine):
+class Microengine(AbstractMicroengine):
     """
     Microengine which scans samples through clamd.
 

--- a/src/microengine/clamav.py
+++ b/src/microengine/clamav.py
@@ -4,7 +4,7 @@ import os
 
 from io import BytesIO
 from polyswarmclient.abstractmicroengine import AbstractMicroengine
-from polyswarmclient.scanner import Scanner
+from polyswarmclient.abstractscanner import AbstractScanner
 
 logger = logging.getLogger(__name__)  # Initialize logger
 
@@ -13,7 +13,7 @@ CLAMD_PORT = int(os.getenv('CLAMD_PORT', '3310'))
 CLAMD_TIMEOUT = 30.0
 
 
-class ClamavScanner(Scanner):
+class Scanner(AbstractScanner):
     def __init__(self):
         self.clamd = clamd.ClamdNetworkSocket(CLAMD_HOST, CLAMD_PORT, CLAMD_TIMEOUT)
 
@@ -52,5 +52,5 @@ class Microengine(AbstractMicroengine):
 
     def __init__(self, client, testing=0, scanner=None, chains=None):
         """Initialize a ClamAV microengine"""
-        scanner = ClamavScanner()
+        scanner = Scanner()
         super().__init__(client, testing, scanner, chains)

--- a/src/microengine/eicar.py
+++ b/src/microengine/eicar.py
@@ -1,13 +1,13 @@
 import base64
 import logging
 
-from polyswarmclient.microengine import Microengine
+from polyswarmclient.abstractmicroengine import AbstractMicroengine
 
 logger = logging.getLogger(__name__)  # Initialize logger
 EICAR = base64.b64decode(b'WDVPIVAlQEFQWzRcUFpYNTQoUF4pN0NDKTd9JEVJQ0FSLVNUQU5EQVJELUFOVElWSVJVUy1URVNULUZJTEUhJEgrSCo=')
 
 
-class EicarMicroengine(Microengine):
+class Microengine(AbstractMicroengine):
     """Microengine which tests for the EICAR test file"""
 
     async def scan(self, guid, content, chain):

--- a/src/microengine/multi.py
+++ b/src/microengine/multi.py
@@ -3,7 +3,7 @@ import logging
 import microengine
 import os
 
-from polyswarmclient.microengine import Microengine
+from polyswarmclient.abstractmicroengine import AbstractMicroengine
 from microengine.clamav import ClamavScanner
 from microengine.yara import YaraScanner
 
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)  # Initialize logger
 BACKENDS = [ClamavScanner, YaraScanner]
 
 
-class MultiMicroengine(Microengine):
+class Microengine(AbstractMicroengine):
     """Microengine which aggregates multiple sub-microengines"""
 
     def __init__(self, client, testing=0, scanner=None, chains=None):

--- a/src/microengine/multi.py
+++ b/src/microengine/multi.py
@@ -4,8 +4,8 @@ import microengine
 import os
 
 from polyswarmclient.abstractmicroengine import AbstractMicroengine
-from microengine.clamav import ClamavScanner
-from microengine.yara import YaraScanner
+from microengine.clamav import Scanner as ClamavScanner
+from microengine.yara import Scanner as YaraScanner
 
 logger = logging.getLogger(__name__)  # Initialize logger
 BACKENDS = [ClamavScanner, YaraScanner]

--- a/src/microengine/scratch.py
+++ b/src/microengine/scratch.py
@@ -1,9 +1,9 @@
 import logging
-from polyswarmclient.microengine import Microengine
+from polyswarmclient.abstractmicroengine import AbstractMicroengine
 
 logger = logging.getLogger(__name__)  # Initialize logger
 
 
-class ScratchMicroengine(Microengine):
+class Microengine(AbstractMicroengine):
     """Scratch microengine is the same as the default behavior."""
     pass

--- a/src/microengine/yara.py
+++ b/src/microengine/yara.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import yara
 
-from polyswarmclient.microengine import Microengine
+from polyswarmclient.abstractmicroengine import AbstractMicroengine
 from polyswarmclient.scanner import Scanner
 
 logger = logging.getLogger(__name__)  # Initialize logger
@@ -38,7 +38,7 @@ class YaraScanner(Scanner):
         return True, False, ''
 
 
-class YaraMicroengine(Microengine):
+class Microengine(AbstractMicroengine):
     """Microengine which matches samples against yara rules"""
 
     def __init__(self, client, testing=0, scanner=None, chains=None):

--- a/src/microengine/yara.py
+++ b/src/microengine/yara.py
@@ -4,13 +4,13 @@ import tempfile
 import yara
 
 from polyswarmclient.abstractmicroengine import AbstractMicroengine
-from polyswarmclient.scanner import Scanner
+from polyswarmclient.abstractscanner import AbstractScanner
 
 logger = logging.getLogger(__name__)  # Initialize logger
 RULES_DIR = os.getenv('RULES_DIR', 'docker/yara-rules')
 
 
-class YaraScanner(Scanner):
+class Scanner(AbstractScanner):
     def __init__(self):
         self.rules = yara.compile(os.path.join(RULES_DIR, "malware/MALW_Eicar"))
 
@@ -49,5 +49,5 @@ class Microengine(AbstractMicroengine):
             testing (int): How many test bounties to respond to
             chains (set[str]): Chain(s) to operate on
         """
-        scanner = YaraScanner()
+        scanner = Scanner()
         super().__init__(client, testing, scanner, chains)

--- a/src/polyswarmclient/abstractambassador.py
+++ b/src/polyswarmclient/abstractambassador.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 import sys
 
+from abc import ABC, abstractmethod
 from polyswarmclient import Client
 from polyswarmclient.events import SettleBounty
 
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)  # Initialize logger
 MAX_TRIES = 10
 
 
-class AbstractAmbassador(object):
+class AbstractAmbassador(ABC):
     def __init__(self, client, testing=0, chains=None, watchdog=0):
         self.client = client
         self.chains = chains
@@ -45,6 +46,7 @@ class AbstractAmbassador(object):
         client = Client(polyswarmd_addr, keyfile, password, api_key, testing > 0, insecure_transport)
         return cls(client, testing, chains, watchdog)
 
+    @abstractmethod
     async def next_bounty(self, chain):
         """Override this to implement different bounty submission queues
 
@@ -59,7 +61,7 @@ class AbstractAmbassador(object):
             |   - **ipfs_uri** (*str*): IPFS URI of the artifact to post
             |   - **duration** (*int*): Duration of the bounty in blocks
         """
-        raise NotImplementedError("You must subclass this class and override this method.")
+        pass
 
     def on_bounty_posted(self, guid, amount, ipfs_uri, expiration, chain):
         """Override this to implement additional steps after bounty submission

--- a/src/polyswarmclient/abstractambassador.py
+++ b/src/polyswarmclient/abstractambassador.py
@@ -9,7 +9,7 @@ logger = logging.getLogger(__name__)  # Initialize logger
 MAX_TRIES = 10
 
 
-class Ambassador(object):
+class AbstractAmbassador(object):
     def __init__(self, client, testing=0, chains=None, watchdog=0):
         self.client = client
         self.chains = chains
@@ -40,7 +40,7 @@ class Ambassador(object):
             chains (set(str)):  Set of chains you are acting on.
 
         Returns:
-            Ambassador: Ambassador instantiated with a Client.
+            AbstractAmbassador: Ambassador instantiated with a Client.
         """
         client = Client(polyswarmd_addr, keyfile, password, api_key, testing > 0, insecure_transport)
         return cls(client, testing, chains, watchdog)
@@ -59,7 +59,7 @@ class Ambassador(object):
             |   - **ipfs_uri** (*str*): IPFS URI of the artifact to post
             |   - **duration** (*int*): Duration of the bounty in blocks
         """
-        return None
+        raise NotImplementedError("You must subclass this class and override this method.")
 
     def on_bounty_posted(self, guid, amount, ipfs_uri, expiration, chain):
         """Override this to implement additional steps after bounty submission

--- a/src/polyswarmclient/abstractarbiter.py
+++ b/src/polyswarmclient/abstractarbiter.py
@@ -8,7 +8,7 @@ from polyswarmclient.events import VoteOnBounty, SettleBounty
 logger = logging.getLogger(__name__)  # Initialize logger
 MAX_STAKE_RETRIES = 10
 
-class Arbiter(object):
+class AbstractArbiter(object):
     def __init__(self, client, testing=0, scanner=None, chains=None):
         self.client = client
         self.chains = chains
@@ -37,7 +37,7 @@ class Arbiter(object):
             chains (set(str)):  Set of chains you are acting on.
 
         Returns:
-            Arbiter: Arbiter instantiated with a Client.
+            AbstractArbiter: Arbiter instantiated with a Client.
         """
         client = Client(polyswarmd_addr, keyfile, password, api_key, testing > 0, insecure_transport)
         return cls(client, testing, scanner, chains)
@@ -61,7 +61,7 @@ class Arbiter(object):
         if self.scanner:
             return await self.scanner.scan(guid, content, chain)
 
-        return False, False, ''
+        raise NotImplementedError("You must subclass this class and override this method.")
 
     def run(self):
         """

--- a/src/polyswarmclient/abstractarbiter.py
+++ b/src/polyswarmclient/abstractarbiter.py
@@ -8,6 +8,7 @@ from polyswarmclient.events import VoteOnBounty, SettleBounty
 logger = logging.getLogger(__name__)  # Initialize logger
 MAX_STAKE_RETRIES = 10
 
+
 class AbstractArbiter(object):
     def __init__(self, client, testing=0, scanner=None, chains=None):
         self.client = client

--- a/src/polyswarmclient/abstractmicroengine.py
+++ b/src/polyswarmclient/abstractmicroengine.py
@@ -7,7 +7,7 @@ from polyswarmclient.events import RevealAssertion, SettleBounty
 logger = logging.getLogger(__name__)  # Initialize logger
 
 
-class Microengine(object):
+class AbstractMicroengine(object):
     def __init__(self, client, testing=0, scanner=None, chains=None):
         self.client = client
         self.chains = chains
@@ -36,7 +36,7 @@ class Microengine(object):
             chains (set(str)):  Set of chains you are acting on.
 
         Returns:
-            Microengine: Microengine instantiated with a Client.
+            AbstractMicroengine: Microengine instantiated with a Client.
         """
         client = Client(polyswarmd_addr, keyfile, password, api_key, testing > 0, insecure_transport)
         return cls(client, testing, scanner, chains)
@@ -60,7 +60,8 @@ class Microengine(object):
         if self.scanner:
             return await self.scanner.scan(guid, content, chain)
 
-        return False, False, ''
+        raise Exception("NOT IMPLEMENTED. "
+                        "You must 1) override this scan method OR 2) provide a scanner to your Microengine constructor")
 
     def bid(self, guid, chain):
         """Override this to implement custom bid calculation logic

--- a/src/polyswarmclient/abstractmicroengine.py
+++ b/src/polyswarmclient/abstractmicroengine.py
@@ -60,8 +60,7 @@ class AbstractMicroengine(object):
         if self.scanner:
             return await self.scanner.scan(guid, content, chain)
 
-        raise Exception("NOT IMPLEMENTED. "
-                        "You must 1) override this scan method OR 2) provide a scanner to your Microengine constructor")
+        raise NotImplementedError("You must 1) override this scan method OR 2) provide a scanner to your Microengine constructor")
 
     def bid(self, guid, chain):
         """Override this to implement custom bid calculation logic

--- a/src/polyswarmclient/abstractscanner.py
+++ b/src/polyswarmclient/abstractscanner.py
@@ -1,4 +1,5 @@
 import logging
+from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)  # Initialize logger
 
@@ -7,7 +8,7 @@ class AbstractScanner(object):
     """
     Base `Scanner` class. To be overwritten with other scanning logic.
     """
-
+    @abstractmethod
     async def scan(self, guid, content, chain):
         """Override this to implement custom scanning logic
 
@@ -23,4 +24,4 @@ class AbstractScanner(object):
             |   - **verdict** (*bool*): Whether this artifact is malicious or not
             |   - **metadata** (*str*): Optional metadata about this artifact
         """
-        raise NotImplementedError("You must subclass this class and override this method.")
+        pass

--- a/src/polyswarmclient/abstractscanner.py
+++ b/src/polyswarmclient/abstractscanner.py
@@ -3,7 +3,7 @@ import logging
 logger = logging.getLogger(__name__)  # Initialize logger
 
 
-class Scanner(object):
+class AbstractScanner(object):
     """
     Base `Scanner` class. To be overwritten with other scanning logic.
     """
@@ -23,4 +23,4 @@ class Scanner(object):
             |   - **verdict** (*bool*): Whether this artifact is malicious or not
             |   - **metadata** (*str*): Optional metadata about this artifact
         """
-        return False, False, ''
+        raise NotImplementedError("You must subclass this class and override this method.")


### PR DESCRIPTION
* Renamed `polyswarmclient.microengine.Microengine` to `polyswarmclient.abstractractmicroengine.AbstractMicroengine`. 
* Now throw an exception if AbstractMicroengine.scan() is called and a scanner was not provided to the subclass's super() constructor.
* Updated sample microengines to use AbstractMicroengine instead of Microengine. 
* Bumped python module version number to 0.2.0 since this is a breaking change. 
* Updated README.md to include a notice that this is a breaking change.