### PR TITLE
bump ver to 1.0rc5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,41 +1,42 @@
 # Release History
 
-### 1.0rc5 (2018-12-XX)
+### 1.0rc5 (2018-12-28)
 
-* Fix - add clamav as an example arbiter
-* Fix - create asyncio locks after changing loop
+* **Feature** - add clamav as an example arbiter
+* **Fix** - create asyncio locks after we change the event loop
+* **Fix** - attempt reconnect on connection errors
+* **Fix** - do not trust polyswarmd
 
 ### 1.0rc4 (2018-12-24)
 
-* Fix - check transaction responses
-* Fix - return empty dict instead of None
-* Fix - better handling of polyswarmd responses
-* Fix - don't clobber API key
-* Fix - clamav example engine to use async socket
-* Fix - asyncio loop change detection for windows hosts
+* **Fix** - check transaction responses
+* **Fix** - return empty dict instead of None on transaction error
+* **Fix** - better handling of polyswarmd responses
+* **Fix** - don't clobber API key if one is set
+* **Fix** - revise clamav example microengine to use async socket
+* **Fix** - asyncio loop change detection for windows hosts
 
 ### 1.0rc3 (2018-12-15)
 
-* Fix - function name corrections that were missed in rc2
-* Fix - remove awaits that don't belong
+* **Fix** - function name corrections that were missed in rc2
+* **Fix** - remove awaits added in rc2 that don't belong
 
 ### 1.0rc2 (2018-12-14)
 
-* Fix - duplicate bounty event handing
-* Fix - enhance log messages with more useful content
-* Feature - allow overriding API key per request
-* Fix - code cleanup and formatting; enhance events class to include block_number and txhash as function args
+* **Fix** - duplicate bounty event handing
+* **Fix** - enhance log messages with more useful content
+* **Feature** - allow overriding API key per request
+* **Fix** - code cleanup and formatting; enhance events class to include block_number and txhash as function args
 
 ### 1.0rc1 (2018-12-11)
 
-* Fix - corrected minimum python3 version
+* **Fix** - corrected minimum python3 version
 
 ### 1.0rc0 (2018-12-07)
 
 Leading up to our PolySwarm 1.0 release, we reset the numbering to 1.0 with release candidates.
 
-* Feature - This is the first release published to PyPi.
-
+* **Feature** - This is the first release published to PyPi.
 
 ### 0.2.0 (2018-11-28)
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,42 @@
 # Release History
 
+### 1.0rc5 (2018-12-XX)
+
+* Fix - add clamav as an example arbiter
+* Fix - create asyncio locks after changing loop
+
+### 1.0rc4 (2018-12-24)
+
+* Fix - check transaction responses
+* Fix - return empty dict instead of None
+* Fix - better handling of polyswarmd responses
+* Fix - don't clobber API key
+* Fix - clamav example engine to use async socket
+* Fix - asyncio loop change detection for windows hosts
+
+### 1.0rc3 (2018-12-15)
+
+* Fix - function name corrections that were missed in rc2
+* Fix - remove awaits that don't belong
+
+### 1.0rc2 (2018-12-14)
+
+* Fix - duplicate bounty event handing
+* Fix - enhance log messages with more useful content
+* Feature - allow overriding API key per request
+* Fix - code cleanup and formatting; enhance events class to include block_number and txhash as function args
+
+### 1.0rc1 (2018-12-11)
+
+* Fix - corrected minimum python3 version
+
+### 1.0rc0 (2018-12-07)
+
+Leading up to our PolySwarm 1.0 release, we reset the numbering to 1.0 with release candidates.
+
+* Feature - This is the first release published to PyPi.
+
+
 ### 0.2.0 (2018-11-28)
 
 * **Feature**: Converted ambassador, arbiter, microengine, and scanner classes to be abstract classes. Updated sample engines to use new design patterns.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as readme:
 
 setup(
     name='polyswarm-client',
-    version='1.0rc4',
+    version='1.0rc5',
     description='Client library to simplify interacting with a polyswarmd instance',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
* updated version to 1.0rc5. 
* filled out major changes for each release in the HISTORY.md file.

We should add any remaining changes to the HISTORY.md before we cut rc5.