### PR TITLE
Exit Client with `os.exit()' when sys.platform == 'win32'

### DIFF
--- a/src/polyswarmclient/__init__.py
+++ b/src/polyswarmclient/__init__.py
@@ -159,7 +159,7 @@ class Client(object):
         if self.exit_code:
             self.exit_loop(self.exit_code)
 
-    def exit_loop(exit_status):
+    def exit_loop(self, exit_status):
         """
         Exit the program entirely.
         """

--- a/src/polyswarmclient/__init__.py
+++ b/src/polyswarmclient/__init__.py
@@ -155,15 +155,21 @@ class Client(object):
         asyncio.get_event_loop().set_exception_handler(self.__exception_handler)
         asyncio.get_event_loop().create_task(self.run_task(chains))
         asyncio.get_event_loop().run_forever()
-        if self.exit_code:
+
+        # NOTE: Refactored the exit handling code here to a new fn to make
+        # codeclimate happy.
+        # If you can find a better way to do this then by all means.
+        def exit_loop(exit_status):
             logger.error('Detected unhandled exception, exiting with failure')
             if sys.platform == 'win32':
                 # XXX: v. hacky. We need to find out what is hanging sys.exit()
                 logger.error("Terminating with os._exit")
-                os._exit(self.exit_code)
+                os._exit(exit_status)
             else:
-                sys.exit(self.exit_code)
+                sys.exit(exit_status)
 
+        if self.exit_code:
+            exit_loop(self.exit_code)
 
     def stop(self):
         """

--- a/src/polyswarmclient/__init__.py
+++ b/src/polyswarmclient/__init__.py
@@ -157,7 +157,13 @@ class Client(object):
         asyncio.get_event_loop().run_forever()
         if self.exit_code:
             logger.error('Detected unhandled exception, exiting with failure')
-            sys.exit(self.exit_code)
+            if sys.platform == 'win32':
+                # XXX: v. hacky. We need to find out what is hanging sys.exit()
+                logger.error("Terminating with os._exit")
+                os._exit(self.exit_code)
+            else:
+                sys.exit(self.exit_code)
+
 
     def stop(self):
         """

--- a/src/polyswarmclient/__init__.py
+++ b/src/polyswarmclient/__init__.py
@@ -163,7 +163,7 @@ class Client(object):
             logger.error('Detected unhandled exception, exiting with failure')
             if sys.platform == 'win32':
                 # XXX: v. hacky. We need to find out what is hanging sys.exit()
-                logger.error("Terminating with os._exit")
+                logger.critical("Terminating with os._exit")
                 os._exit(exit_status)
             else:
                 sys.exit(exit_status)

--- a/src/polyswarmclient/__init__.py
+++ b/src/polyswarmclient/__init__.py
@@ -156,20 +156,20 @@ class Client(object):
         asyncio.get_event_loop().create_task(self.run_task(chains))
         asyncio.get_event_loop().run_forever()
 
-        # NOTE: Refactored the exit handling code here to a new fn to make
-        # codeclimate happy.
-        # If you can find a better way to do this then by all means.
-        def exit_loop(exit_status):
-            logger.error('Detected unhandled exception, exiting with failure')
-            if sys.platform == 'win32':
-                # XXX: v. hacky. We need to find out what is hanging sys.exit()
-                logger.critical("Terminating with os._exit")
-                os._exit(exit_status)
-            else:
-                sys.exit(exit_status)
-
         if self.exit_code:
-            exit_loop(self.exit_code)
+            self.exit_loop(self.exit_code)
+
+    def exit_loop(exit_status):
+        """
+        Exit the program entirely.
+        """
+        logger.error('Detected unhandled exception, exiting with failure')
+        if sys.platform == 'win32':
+            # XXX: v. hacky. We need to find out what is hanging sys.exit()
+            logger.critical("Terminating with os._exit")
+            os._exit(exit_status)
+        else:
+            sys.exit(exit_status)
 
     def stop(self):
         """


### PR DESCRIPTION
This code calls `os._exit` which is a hard exit. No exception handlers/destructors/exit routines are run, threads die, etc.

This begs the question:

Can we handle clean-up manually *prior* to calling `sys.exit`?

Can we manually see what exception handler *would* be called if an exception *were* to be invoked (possibly allowing us to fix it)? If it's not an exception handler issue - is it outstanding threads?

[_voice grows increasingly insane_] Can we reach into a python coredump and reconcile regular python pdb symbols with interpreter state to reconstruct where in the application it is hanging at a "high level"?

The possibilities for how to handle this are endless but this code here does have the advantage of working now and showing no clear defects.

