### PR TITLE
Fix missing parens for function call

### DIFF
--- a/src/polyswarmclient/transaction.py
+++ b/src/polyswarmclient/transaction.py
@@ -219,7 +219,7 @@ class AbstractTransaction(metaclass=ABCMeta):
                 logger.warning('Error fetching some receipts, retrying')
                 continue
 
-            if any(['transaction failed' in e.lower for e in get_errors]):
+            if any(['transaction failed' in e.lower() for e in get_errors]):
                 logger.error('Transaction failed due to bad parameters, not retrying', extra={'extra': get_errors})
                 break
 


### PR DESCRIPTION
Fixes following error
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/asyncio/tasks.py", line 240, in _step
    result = coro.send(None)
  File "/usr/local/lib/python3.5/site-packages/polyswarmclient/events.py", line 359, in run
    return await super().run(bounty_guid, chain)
  File "/usr/local/lib/python3.5/site-packages/polyswarmclient/events.py", line 49, in run
    local_ret = await cb(*args, **kwargs)
  File "/usr/local/lib/python3.5/site-packages/polyswarmclient/abstractambassador.py", line 246, in __handle_settle_bounty
    ret = await self.client.bounties.settle_bounty(bounty_guid, chain)
  File "/usr/local/lib/python3.5/site-packages/polyswarmclient/bountiesclient.py", line 411, in settle_bounty
    success, result = await transaction.send(chain, api_key=api_key)
  File "/usr/local/lib/python3.5/site-packages/polyswarmclient/transaction.py", line 222, in send
    if any(['transaction failed' in e.lower for e in get_errors]):
  File "/usr/local/lib/python3.5/site-packages/polyswarmclient/transaction.py", line 222, in <listcomp>
    if any(['transaction failed' in e.lower for e in get_errors]):
TypeError: argument of type 'builtin_function_or_method' is not iterable
```