### PR TITLE
downgrade packer to a known working version pre CI changes

### DIFF
--- a/docker/ci-image/Dockerfile
+++ b/docker/ci-image/Dockerfile
@@ -3,6 +3,6 @@ FROM docker:stable
 RUN apk --no-cache add curl jq unzip py3-pip && \
     pip3 install --upgrade pip && \
     pip3 install docker-compose wheel && \
-    curl https://releases.hashicorp.com/packer/1.3.5/packer_1.3.5_linux_amd64.zip > packer.zip && \
+    curl https://releases.hashicorp.com/packer/1.3.1/packer_1.3.1_linux_amd64.zip > packer.zip && \
     unzip -d /usr/bin/ packer.zip && \
     rm -f packer.zip


### PR DESCRIPTION
packer failing CI.  Checking if new packer update it the issue.  rolling back to v1.3.1