### PR TITLE
Remove ethereum module

### DIFF
--- a/docker/windows/base/polyswarm-profile.ps1
+++ b/docker/windows/base/polyswarm-profile.ps1
@@ -57,8 +57,8 @@ function Install-Service {
     #>
 
     Param(
-        [Parameter(Mandatory = $true)][String] $Name,
-        [Parameter(Mandatory = $true)][String] $Path,
+        [String] $Name,
+        [String] $Path,
         [String] $AppDirectory = "C:\$Name",
         [String] $AppExit = "Default Restart",
         $AppRestartDelay = 250,
@@ -66,6 +66,10 @@ function Install-Service {
         [String] $AppStdErr = "$AppStdOut",
         [String] $StartType = "SERVICE_AUTO_START"
     )
+
+    # Unfortunately, can't use `Parameter(Mandatory = $true)]' w/ $args
+    if (!$Name) { throw "Must supply a name to Install-Service" }
+    if (!$Path) { throw "Must supply a Path to Install-Service" }
 
     Get-Command "nssm"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ base58==0.2.5
 git+https://github.com/polyswarm/python-clamd.git@async#egg=clamd
 click==6.7
 coverage==4.5.1
-ethereum==2.3.2
+pycryptodome>=3.4.7
 hypothesis==3.82.1
 pytest==3.9.2
 pytest-asyncio==0.9.0

--- a/src/polyswarmclient/utils.py
+++ b/src/polyswarmclient/utils.py
@@ -3,10 +3,11 @@ import logging
 import os
 import sys
 import uuid
+
+from Crypto.Hash import keccak
 from concurrent.futures import ThreadPoolExecutor
 
 import base58
-from ethereum.utils import sha3
 
 logger = logging.getLogger(__name__)
 
@@ -14,11 +15,23 @@ TASK_TIMEOUT = 1.0
 MAX_WAIT = int(os.getenv("WORKER_BACKOFF", "3"))
 MAX_WORKERS = 4
 
+def to_string(value):
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return bytes(value, 'utf-8')
+    if isinstance(value, int):
+        return bytes(str(value), 'utf-8')
+
+def sha3_256(x):
+    return keccak.new(digest_bits=256, data=x).digest()
+
+def sha3(seed):
+    return sha3_256(to_string(seed))
 
 def int_to_bytes(i):
     h = hex(i)[2:]
     return bytes.fromhex('0' * (64 - len(h)) + h)
-
 
 def int_from_bytes(b):
     return int.from_bytes(b, byteorder='big')

--- a/src/polyswarmclient/verifiers.py
+++ b/src/polyswarmclient/verifiers.py
@@ -3,10 +3,9 @@ from abc import ABCMeta, abstractmethod
 
 from eth_abi import decode_abi
 from eth_abi.exceptions import InsufficientDataBytes
-from ethereum.utils import sha3
 from hexbytes import HexBytes
 
-from polyswarmclient.utils import int_to_bool_list, guid_as_string
+from polyswarmclient.utils import int_to_bool_list, guid_as_string, sha3
 
 logger = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import pytest
 import tempfile
+import sys
 
 from . import success
 from aioresponses import aioresponses
@@ -78,7 +79,10 @@ class WebsocketMock(object):
 
 class MockClient(Client):
     def __init__(self):
-        with tempfile.NamedTemporaryFile() as tf:
+        # write will complain about permissions if `NamedTemporaryFile' is
+        # delete=True under windows.
+        do_delete = sys.platform != 'win32'
+        with tempfile.NamedTemporaryFile(delete=do_delete) as tf:
             tf.write(TESTKEY)
             tf.flush()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,9 @@ import pytest
 import polyswarmclient
 import random
 import uuid
+from os import urandom
+
+from unittest.mock import patch
 
 import polyswarmclient.transaction
 import polyswarmclient.utils
@@ -27,6 +30,14 @@ def test_is_valid_ipfs_uri():
     valid_ipfs_uri = 'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
     assert polyswarmclient.utils.is_valid_ipfs_uri(valid_ipfs_uri)
 
+@patch('os.urandom', return_value=0x41)
+def test_calculate_commitment(mock_fn):
+    nonce, commitment = polyswarmclient.utils.calculate_commitment(
+        "0x4141414141414141414141414141414141414141414141414141414141414141",
+        polyswarmclient.utils.bool_list_to_int([True, True, True])
+    )
+    assert nonce == 65
+    assert commitment == 16260335923677497924282686029038487427342546648292884828210727571478684022780
 
 @pytest.mark.asyncio
 async def test_update_base_nonce(mock_client):

--- a/tests/test_verifiers.py
+++ b/tests/test_verifiers.py
@@ -1,0 +1,9 @@
+import pytest
+from polyswarmclient.utils import sha3
+
+def test_verifier_sha3():
+    ABIS = [(b'\xa9\x05\x9c\xbb', ('transfer', ['address', 'uint256'])),
+            (b'\x9b\x1c\xda\xd4', ('postBounty', ['uint128', 'uint256', 'string', 'uint256', 'uint256', 'uint256[8]']))]
+    for result, abi in ABIS:
+        method, args = abi
+        assert result == sha3('{}({})'.format(method, ','.join(args)))[:4]


### PR DESCRIPTION
This patch removes all instances of the `ethereum` module referenced in `polyswarm-client`'s Python code, ending a slew of Windows build issues arising from this package's dependencies.

Today, the amount of code referencing the `ethereum` module in `polyswarm-client` has shrunk to the extent that only it's implementation of sha3/Keccak remains; All usages of this `sha3` function have been replaced with the reference implementation upstream along with unit tests to verify absence of regressions in functions calling `ethereum.utils.sha3`