### PR TITLE
Fix `NamedTemporaryFile' permissions issue in MockClient under Windows

### DIFF
--- a/docker/windows/base/polyswarm-profile.ps1
+++ b/docker/windows/base/polyswarm-profile.ps1
@@ -57,8 +57,8 @@ function Install-Service {
     #>
 
     Param(
-        [Parameter(Mandatory = $true)][String] $Name,
-        [Parameter(Mandatory = $true)][String] $Path,
+        [String] $Name,
+        [String] $Path,
         [String] $AppDirectory = "C:\$Name",
         [String] $AppExit = "Default Restart",
         $AppRestartDelay = 250,
@@ -66,6 +66,10 @@ function Install-Service {
         [String] $AppStdErr = "$AppStdOut",
         [String] $StartType = "SERVICE_AUTO_START"
     )
+
+    # Unfortunately, can't use `Parameter(Mandatory = $true)]' w/ $args
+    if (!$Name) { throw "Must supply a name to Install-Service" }
+    if (!$Path) { throw "Must supply a Path to Install-Service" }
 
     Get-Command "nssm"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import pytest
 import tempfile
+import sys
 
 from . import success
 from aioresponses import aioresponses
@@ -78,7 +79,10 @@ class WebsocketMock(object):
 
 class MockClient(Client):
     def __init__(self):
-        with tempfile.NamedTemporaryFile() as tf:
+        # write will complain about permissions if `NamedTemporaryFile' is
+        # delete=True under windows.
+        do_delete = sys.platform != 'win32'
+        with tempfile.NamedTemporaryFile(delete=do_delete) as tf:
             tf.write(TESTKEY)
             tf.flush()
 


### PR DESCRIPTION
This fixes a fatal file permission issue on the temporary files created when running under Windows.