### PR TITLE
Reset tries value on successful response

### DIFF
--- a/src/worker/__init__.py
+++ b/src/worker/__init__.py
@@ -152,6 +152,7 @@ class Worker(object):
                 key = f'{self.queue}_{guid}_{chain}_results'
                 try:
                     await redis.rpush(key, j)
+                    self.tries = 0
                 except OSError:
                     logger.exception('Redis connection down')
                 except aioredis.errors.ReplyError:


### PR DESCRIPTION
We see a number of `socker.gaierror` in workers, which builds up to 15 seconds, then stays there forever causing missed bounties. 
This reset that value on a successful scan result sent back over redis. 