### PR TITLE
Don't block redis conn with blpop

### DIFF
--- a/src/polyswarmclient/producer.py
+++ b/src/polyswarmclient/producer.py
@@ -40,12 +40,16 @@ class Producer:
         logger.info(f' timeout set to {timeout}')
 
         async def wait_for_result(result_key):
+            remaining = KEY_TIMEOUT
             try:
                 with await self.redis as redis:
-                    result = await redis.blpop(result_key, timeout=timeout)
+                    result = await redis.blpop(result_key, timeout=0)
                     if result is None:
-                        logger.critical('Timeout waiting for result in bounty %s', guid)
-                        return None
+                        if remaining == 0:
+                            logger.critical('Timeout waiting for result in bounty %s', guid)
+                            return None
+                        else:
+                            await asyncio.sleep(1)
 
                     j = json.loads(result[1].decode('utf-8'))
 

--- a/src/polyswarmclient/producer.py
+++ b/src/polyswarmclient/producer.py
@@ -43,14 +43,18 @@ class Producer:
             remaining = KEY_TIMEOUT
             try:
                 with await self.redis as redis:
-                    result = await redis.blpop(result_key, timeout=0)
-                    if result is None:
+                    while True:
+                        result = await redis.blpop(result_key, timeout=0)
+
+                        if result:
+                            break
+
                         if remaining == 0:
                             logger.critical('Timeout waiting for result in bounty %s', guid)
                             return None
-                        else:
-                            remaining -= 1
-                            await asyncio.sleep(1)
+
+                        remaining -= 1
+                        await asyncio.sleep(1)
 
                     j = json.loads(result[1].decode('utf-8'))
 

--- a/src/polyswarmclient/producer.py
+++ b/src/polyswarmclient/producer.py
@@ -49,6 +49,7 @@ class Producer:
                             logger.critical('Timeout waiting for result in bounty %s', guid)
                             return None
                         else:
+                            remaining -= 1
                             await asyncio.sleep(1)
 
                     j = json.loads(result[1].decode('utf-8'))


### PR DESCRIPTION
This is the result of us seeing some weird behavior in prod, and I believe is the fix.

The behavior in question was as follows: engines would begin reporting every bounty they got off their queue as expired. Times on producer/workers appeared to be synced properly. The queues themselves appeared to be empty 99% of the time, but the bounties they were reporting grabbing were very old (minutes to hours old).

After some looking around for root cause, I believe what is happening is that these `blpop`s waiting on results are blocking all the redis connections (10 max in the pool by default), meaning that the producers will only allow ~10 outstanding bounties at any given time (as it will start waiting on results for all of them). Any bounties scheduled after this begin to pile up in the async loop, waiting on the redis connections to unblock to then send their `rpush`.

Let me know if this makes sense to you @Rizato as this is new code to me so I might have missed something.