### PR TITLE
Indicate metadata should be json-parsable string

### DIFF
--- a/src/polyswarmclient/abstractscanner.py
+++ b/src/polyswarmclient/abstractscanner.py
@@ -16,7 +16,7 @@ class ScanResult(object):
             bit (bool): Are we asserting on this artifact
             verdict (bool): Is this artifact malicious (True) or benign (False)
             confidence (float): How confident are we in our verdict ranging from 0.0 to 1.0
-            metadata (str): Optional metadata from the scan
+            metadata (json str): Optional metadata from the scan
         """
         self.bit = bit
         self.verdict = verdict


### PR DESCRIPTION
It looks like metadata is intended to be parsable as a json string and this should be reflected in the comments.