### PR TITLE
Do not discard results when running solo microengines

### DIFF
--- a/src/polyswarmclient/abstractmicroengine.py
+++ b/src/polyswarmclient/abstractmicroengine.py
@@ -138,6 +138,7 @@ class AbstractMicroengine(object):
                 result = await self.scan(guid, artifact_type, content, artifact_metadata, chain)
                 if result.bit:
                     result.confidence = self.confidence_modifier.modify(artifact_metadata, result.confidence)
+                    return result
 
             return ScanResult()
 


### PR DESCRIPTION
When running microengines that are not in the producer/consumer model, the original `fetch_and_scan()` code discards the `ScanResult()` instance from the scanner, returning an empty `ScanResult()` instead, which means "no assertion". This fix uses the existing `ScanResult()` in case the bit mask is set.

This bug was compromising our `e2e` tests. Thanks @mrtizmoatwork for the help looking into it.