### PR TITLE
Create new session if in conn-refused loop

### DIFF
--- a/src/polyswarmclient/__init__.py
+++ b/src/polyswarmclient/__init__.py
@@ -561,6 +561,7 @@ class Client(object):
             # Handles unique case where websocket is connected, but http requests are conn refused
             if self.connection_refused > 15:
                 logger.warning('Too many connection refused in a row, retrying')
+                self.connection_refused = 0
                 raise ConnectionRefusedError('Too many connection refused in a row, retrying')
 
     def schedule(self, expiration, event, chain):

--- a/src/polyswarmclient/__init__.py
+++ b/src/polyswarmclient/__init__.py
@@ -147,19 +147,13 @@ class Client(object):
         self.params = {'account': self.account}
 
         # We can now create our locks, because we are assured that the event loop is set
-        if self.nonce_managers is None:
-            self.nonce_managers = {chain: NonceManager(self, chain) for chain in chains}
-        else:
-            for chain in chains:
-                if self.nonce_managers.get(chain) is None:
-                    self.nonce_managers[chain] = NonceManager(self, chain)
 
-        if self.__schedules is None:
-            self.__schedules = {chain: events.Schedule() for chain in chains}
-        else:
-            for chain in chains:
-                if self.__schedules.get(chain) is None:
-                    self.__schedules[chain] = events.Schedule()
+        for chain in chains:
+            if self.nonce_managers.get(chain, None) is None:
+                self.nonce_managers[chain] = NonceManager(self, chain)
+
+            if self.__schedules.get(chain, None) is None:
+                self.__schedules[chain] = events.Schedule()
 
         if self.connection_refused_lock is None:
             self.connection_refused_lock = asyncio.Lock()
@@ -275,6 +269,7 @@ class Client(object):
                     return False, response.get('errors')
 
             await self.clear_refused()
+
             return True, response.get('result')
 
         return False, response.get('errors')

--- a/src/polyswarmclient/exceptions.py
+++ b/src/polyswarmclient/exceptions.py
@@ -26,3 +26,10 @@ class InvalidBidError(PolyswarmClientException):
     Fault in bid logic that resulted in a bid that is not between the min and max values provided by polyswarmd
     """
     pass
+
+
+class ConnectionRefused(PolyswarmClientException):
+    """
+    polyswarm-client is unable to connect to polyswarmd for some reason
+    """
+    pass


### PR DESCRIPTION
We are experience a case on stage where the websocket is connected and new bounties are coming in, but all http requests get connection refused. It can be fixed with a restart. 

This is attempting to trigger a new session, and see if that solves the issue without a restart