### PR TITLE
Sync requirements.txt & setup.py, downgrade async-timeout.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-async-timeout<4.0,>=3.0 # async-timeout<4.0,>=3.0 is required by {'aiohttp'} where aioredis is agnostic
+async-timeout<4.0,>=3.0
 aiohttp==3.6.2
 aiodns==1.2.0
 aioredis==1.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-aiodns==1.2.0
+async-timeout<4.0,>=3.0 # async-timeout<4.0,>=3.0 is required by {'aiohttp'} where aioredis is agnostic
 aiohttp==3.6.2
+aiodns==1.2.0
 aioredis==1.3.1
 aioresponses==0.6.0
 aiorwlock==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as readme:
 
 def parse_requirements():
     with open('requirements.txt', 'r') as f:
-        return ['{2} @ {0}'.format(*r.partition('#egg=')) if '#egg=' in r else r for r in f.read().splitlines()]
+        return ['{2} @ {0}{1}{2}'.format(*r.partition('#egg=')) if '#egg=' in r else r for r in f.read().splitlines()]
 
 setup(
     name='polyswarm-client',

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,10 @@ with open("README.md", "r") as readme:
     long_description = readme.read()
 
 
+def parse_requirements():
+    with open('requirements.txt', 'r') as f:
+        return ['{2} @ {0}'.format(*r.partition('#egg=')) if '#egg=' in r else r for r in f.read().splitlines()]
+
 setup(
     name='polyswarm-client',
     version='2.7.4',
@@ -17,24 +21,7 @@ setup(
     url='https://github.com/polyswarm/polyswarm-client',
     license='MIT',
     python_requires='>=3.6.5,<4',
-    install_requires=[
-        'aiodns==1.2.0',
-        'aiohttp==3.6.2',
-        'aioredis==1.2.0',
-        'aioresponses==0.6.0',
-        'aiorwlock==0.6.0',
-        'backoff==1.10.0',
-        'base58==0.2.5',
-        'click==6.7',
-        'dataclasses==0.7; python_version == "3.6"',
-        'polyswarm-artifact>=1.3.1',
-        'python-json-logger==0.1.9',
-        'python-magic-bin==0.4.14;platform_system=="Windows"',
-        'python-magic==0.4.15;platform_system=="Linux"',
-        'web3==4.8.2',
-        'websockets==6.0',
-        'yara-python==3.7.0',
-    ],
+    install_requires=parse_requirements(),
     include_package_data=True,
     packages=find_packages('src'),
     package_dir={'': 'src'},

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,16 @@ setup(name='polyswarm-client',
       package_dir={'': 'src'},
       packages=find_packages('src'),
       python_requires='>=3.6.5,<4',
-      setup_requires=['pytest'],
+      setup_requires=[
+          'pytest-runner',
+      ],
       test_suite='tests',
-      tests_require=['pytest-runner'],
-
+      tests_require=[
+          'pytest==3.9.2',
+          'pytest-asyncio==0.9.0',
+          'pytest-cov==2.6.0',
+          'pytest-timeout==1.3.2',
+      ],
       entry_points={
           'console_scripts': [
               'ambassador=ambassador.__main__:main',

--- a/setup.py
+++ b/setup.py
@@ -1,48 +1,54 @@
 from setuptools import find_packages, setup
 
 
+def parse_requirements():
+    with open('requirements.txt', 'r') as f:
+        return [
+            '{2} @ {0}{1}{2}'.format(*r.partition('#egg=')) if '#egg=' in r else r
+            for r in f.read().splitlines()
+        ]
+
+
 # The README.md will be used as the content for the PyPi package details page on the Python Package Index.
 with open("README.md", "r") as readme:
     long_description = readme.read()
 
+setup(name='polyswarm-client',
+      version='2.7.4',
+      description='Client library to simplify interacting with a polyswarmd instance',
+      long_description=long_description,
+      long_description_content_type="text/markdown",
+      author='PolySwarm Developers',
+      author_email='info@polyswarm.io',
+      url='https://github.com/polyswarm/polyswarm-client',
+      license='MIT',
 
-def parse_requirements():
-    with open('requirements.txt', 'r') as f:
-        return ['{2} @ {0}{1}{2}'.format(*r.partition('#egg=')) if '#egg=' in r else r for r in f.read().splitlines()]
+      include_package_data=True,
+      install_requires=parse_requirements(),
+      package_dir={'': 'src'},
+      packages=find_packages('src'),
+      python_requires='>=3.6.5,<4',
+      setup_requires=['pytest'],
+      test_suite='tests',
+      tests_require=['pytest-runner'],
 
-setup(
-    name='polyswarm-client',
-    version='2.7.4',
-    description='Client library to simplify interacting with a polyswarmd instance',
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    author='PolySwarm Developers',
-    author_email='info@polyswarm.io',
-    url='https://github.com/polyswarm/polyswarm-client',
-    license='MIT',
-    python_requires='>=3.6.5,<4',
-    install_requires=parse_requirements(),
-    include_package_data=True,
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    entry_points={
-        'console_scripts': [
-            'ambassador=ambassador.__main__:main',
-            'arbiter=arbiter.__main__:main',
-            'liveliness=liveness.__main__:main',
-            'liveness=liveness.__main__:main',
-            'microengine=microengine.__main__:main',
-            'verbatimdbgen=arbiter.verbatimdb.__main__:main',
-            'balancemanager=balancemanager.__main__:cli',
-            'worker=worker.__main__:main',
-        ],
-    },
-    classifiers=[
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: Implementation :: PyPy",
-    ]
-)
+      entry_points={
+          'console_scripts': [
+              'ambassador=ambassador.__main__:main',
+              'arbiter=arbiter.__main__:main',
+              'liveliness=liveness.__main__:main',
+              'liveness=liveness.__main__:main',
+              'microengine=microengine.__main__:main',
+              'verbatimdbgen=arbiter.verbatimdb.__main__:main',
+              'balancemanager=balancemanager.__main__:cli',
+              'worker=worker.__main__:main',
+          ],
+      },
+      classifiers=[
+          "Intended Audience :: Developers",
+          "License :: OSI Approved :: MIT License",
+          "Operating System :: OS Independent",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Programming Language :: Python :: Implementation :: PyPy",
+      ])

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,6 @@
 from setuptools import find_packages, setup
 
 
-def parse_requirements():
-    with open('requirements.txt', 'r') as f:
-        return [
-            '{2} @ {0}{1}{2}'.format(*r.partition('#egg=')) if '#egg=' in r else r
-            for r in f.read().splitlines()
-        ]
-
-
 # The README.md will be used as the content for the PyPi package details page on the Python Package Index.
 with open("README.md", "r") as readme:
     long_description = readme.read()
@@ -22,17 +14,37 @@ setup(name='polyswarm-client',
       author_email='info@polyswarm.io',
       url='https://github.com/polyswarm/polyswarm-client',
       license='MIT',
-
       include_package_data=True,
-      install_requires=parse_requirements(),
+      install_requires=[
+          'async-timeout<4.0,>=3.0',
+          'aiohttp==3.6.2',
+          'aiodns==1.2.0',
+          'aioredis==1.3.1',
+          'aioresponses==0.6.0',
+          'aiorwlock==0.6.0',
+          'asynctest==0.12.2',
+          'backoff==1.10.0',
+          'base58==0.2.5',
+          'click==6.7',
+          "dataclasses==0.7; python_version == '3.6'",
+          'jsonschema==3.0.2',
+          'hypothesis==3.82.1',
+          'polyswarm-artifact>=1.3.1',
+          'pycryptodome>=3.4.7',
+          'python-json-logger==0.1.9',
+          'python-magic-bin==0.4.14;platform_system=="Windows"',
+          'python-magic==0.4.15;platform_system=="Linux"',
+          'web3==4.8.2',
+          'websockets==6.0',
+          'yara-python==3.7.0',
+      ],
       package_dir={'': 'src'},
       packages=find_packages('src'),
       python_requires='>=3.6.5,<4',
-      setup_requires=[
-          'pytest-runner',
-      ],
       test_suite='tests',
       tests_require=[
+          'coverage==4.5.1',
+          'tox==3.4.0',
           'pytest==3.9.2',
           'pytest-asyncio==0.9.0',
           'pytest-cov==2.6.0',


### PR DESCRIPTION
`async-timeout<4.0,>=3.0` is required by `aiohttp` whereas `aioredis` doesn't request a particular version.

We could install `aiohttp` before `aioredis` as well, but let's make it explicit for future generations.