### PR TITLE
Update pip version in our docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 *.pyc
 venv/
+env/
 __pycache__/
 .pytest_cache
 .tox

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ For important changes releases, see the [Release History](https://github.com/pol
 
 ## Installation
 
-You need python3 >= 3.6.5.
-Then to install polyswarm-client, use pip
+You need python3 >= 3.6.5 and pip >= 20.0.
+Then use pip to install polyswarm-client.
 
 ```python
 pip install polyswarm-client

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,8 @@ WORKDIR /usr/src/app
 
 COPY requirements.txt ./
 
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install -U pip \
+    && pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src/app
 
 COPY requirements.txt ./
 
-RUN pip install -U pip \
+RUN pip install -U pip wheel \
     && pip install --no-cache-dir -r requirements.txt
 
 COPY . .

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -18,7 +18,7 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
 
 ## -- Install polyswarm-client -----------
 COPY . C:/polyswarm/polyswarm-client
-RUN pip install -U pip; `
+RUN python -m pip install -U pip; `
     pip install                                       `
     --no-warn-script-location                         `
     -r C:/polyswarm/polyswarm-client/requirements.txt `

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -11,15 +11,15 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
     ## Needed to build native extensions
     choco install -y git; `
     choco install -y vcbuildtools --version 2015.4; `
-    ## Install python3 and upgrade pip
+    ## Install python3
     choco install -y python --version 3.6.7; `
-    python -m pip install -U pip; `
     ## -- Utilities ---------------------------
     choco install -y vim-console
 
 ## -- Install polyswarm-client -----------
 COPY . C:/polyswarm/polyswarm-client
-RUN pip install                                       `
+RUN pip install -U pip; `
+    pip install                                       `
     --no-warn-script-location                         `
     -r C:/polyswarm/polyswarm-client/requirements.txt `
     C:/polyswarm/polyswarm-client/; `

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -11,8 +11,9 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
     ## Needed to build native extensions
     choco install -y git; `
     choco install -y vcbuildtools --version 2015.4; `
-    ## Install basic polyswarm python pkgs
+    ## Install python3 and upgrade pip
     choco install -y python --version 3.6.7; `
+    python -m pip install -U pip; `
     ## -- Utilities ---------------------------
     choco install -y vim-console
 

--- a/docker/windows/Dockerfile
+++ b/docker/windows/Dockerfile
@@ -18,7 +18,7 @@ RUN iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.or
 
 ## -- Install polyswarm-client -----------
 COPY . C:/polyswarm/polyswarm-client
-RUN python -m pip install -U pip; `
+RUN python -m pip install -U pip wheel; `
     pip install                                       `
     --no-warn-script-location                         `
     -r C:/polyswarm/polyswarm-client/requirements.txt `


### PR DESCRIPTION
This is needed to work with newer python packaging formats, which we are using in microengine-utils project.