### PR TITLE
Don't build engine images in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -225,63 +225,14 @@ release-latest-windows:
 # Deployment Stage
 ###############################################################
 
-kick-after-complete1:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-ikarus
-
-kick-after-complete3:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-drweb
-
-kick-after-complete4:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-rising
-
-kick-after-complete5:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-iris-h
-kick-after-complete6:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-intezer-analyze
-
-kick-after-complete7:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-zerocert
-
-kick-after-complete8:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-virusdie
-kick-after-complete9:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-cyradar
-
-kick-after-complete10:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-nucleon
-
-kick-after-complete12:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/polyswarm-client-windows
+kick-polyswarm-client-internal:
+  stage: postbuild
+  needs:
+    - test-windows
+    - test-linux
+  trigger:
+    project: externalci/polyswarm-client-internal
+    strategy: depend
 
 kick-after-complete13:
   stage: deployment
@@ -298,63 +249,3 @@ kick-after-complete14:
   only:
     - master
   trigger: externalci/consumer
-
-kick-after-complete15:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-crowdstrike-falcon
-
-kick-after-complete17:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-inscyt
-
-kick-after-complete18:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-phishtank
-
-kick-after-complete19:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/arbiter-hatchingtriage
-
-kick-after-complete20:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-quttera
-
-kick-after-complete21:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-concinnity
-
-kick-after-complete22:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-venustech
-
-kick-after-complete23:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-notmining
-
-kick-after-complete24:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-urlhaus
-
-kick-after-complete25:
-  stage: deployment
-  only:
-    - master
-  trigger: externalci/microengine-urlscanio

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -226,10 +226,9 @@ release-latest-windows:
 ###############################################################
 
 kick-polyswarm-client-internal:
-  stage: postbuild
-  needs:
-    - test-windows
-    - test-linux
+  stage: deployment
+  only:
+    - master
   trigger:
     project: externalci/polyswarm-client-internal
     strategy: depend


### PR DESCRIPTION
We've moved this logic into `polyswarm-client-internal`